### PR TITLE
Add storage location for nodes

### DIFF
--- a/anm/anm-local.sh
+++ b/anm/anm-local.sh
@@ -172,6 +172,14 @@ elif [[ "$SELECTION" == "7" ]]; then
     # Set new rewards address
     sudo sed -i 's/--rewards-address EtheriumAddress/--rewards-address '$RewardsAddress'/g' /usr/bin/anms.sh
 
+    ### set node storage location
+    NodeStorage=$(whiptail --title "Node Storage Location" --inputbox "\nEnter the path to store node information" 8 40 "/var/antctl/services/" 3>&1 1>&2 2>&3)
+    if [[ $? -eq 255 ]]; then
+        exit 0
+    fi
+    # Set new storage location
+    sudo sed -i 's,NodeStorage=/var/antctl/services,/NodeStorage='$NodeStorage'/g' /usr/bin/anms.sh
+
     ### set nodecount
     NodeCount=$(whiptail --title "Set node count" --inputbox "\nEnter node count" 8 40 "20" 3>&1 1>&2 2>&3)
     if [[ $? -eq 255 ]]; then

--- a/anm/scripts/anms.sh
+++ b/anm/scripts/anms.sh
@@ -46,8 +46,8 @@ CheckSetUp() {
         sudo useradd -m -p ed5wsejw6S4ifjlwjfSlwj ant
         sudo mkdir -p /var/antctl/
         sudo chown -R $USER:$USER /var/antctl/
-        sudo mkdir -p /var/antctl/services/ /var/log/antnode/ /var/antctl/bootstrap-cache/
-        sudo chown -R ant:ant /var/antctl/services/ /var/log/antnode/ /var/antctl/bootstrap-cache/
+        sudo mkdir -p $NodeStorage/ /var/log/antnode/ /var/antctl/bootstrap-cache/
+        sudo chown -R ant:ant $NodeStorage/ /var/log/antnode/ /var/antctl/bootstrap-cache/
         echo "CpuCount=$(echo "$(nproc) / 1" | bc)" >>/var/antctl/system
         . /var/antctl/system
         echo "CounterStart=0" >>/var/antctl/counters
@@ -78,6 +78,8 @@ CheckSetUp() {
         echo "DelayReStart=5" >>/var/antctl/config
         echo "DelayUpgrade=5" >>/var/antctl/config
         echo "DelayRemove=10" >>/var/antctl/config
+        echo >>/var/antctl/cofig
+        echo "NodeStorage=/var/antctl/services" >>/var/antctl/config
         echo >>/var/antctl/config
         echo "NodeCap=20" >>/var/antctl/config
         echo >>/var/antctl/config
@@ -134,7 +136,7 @@ StartNode() {
     # PeerId=$(echo "$status" | grep "id=" | cut -f2 -d= | cut -d '`' -f 1)
     node_metadata="$(curl -s 127.0.0.1:13$node_number/metadata)"
     PeerId="$(echo "$node_metadata" | grep ant_networking_peer_id | awk 'NR==3 {print $1}' | cut -d'"' -f 2)"
-    node_details_store[$node_number]="$node_name,$PeerId,$(/var/antctl/services/$node_name/antnode --version | awk 'NR==1 {print $3}' | cut -c2-),RUNNING"
+    node_details_store[$node_number]="$node_name,$PeerId,$($NodeStorage/$node_name/antnode --version | awk 'NR==1 {print $3}' | cut -c2-),RUNNING"
     echo "$node_name Started"
     sed -i 's/CounterStart=.*/CounterStart='$DelayStart'/g' /var/antctl/counters
     echo "reset node start timer" && echo
@@ -147,18 +149,18 @@ AddNode() {
     echo ""$time_hour":"$time_min" Add $node_name $RewardsAddress" >>/var/antctl/simplelog
     echo ""$time_hour":"$time_min" Add $node_name $RewardsAddress" >>/var/antctl/wallet-log
     echo "Adding $node_name"
-    sudo mkdir -p /var/antctl/services/$node_name /var/log/antnode/$node_name
-    echo "mkdir -p /var/antctl/services/$node_name"
-    sudo cp $NodePath /var/antctl/services/$node_name
-    echo "cp $NodePath /var/antctl/services/$node_name"
-    sudo chown -R ant:ant /var/antctl/services/$node_name /var/log/antnode/$node_name /var/antctl/services/$node_name/antnode
+    sudo mkdir -p $NodeStorage/$node_name /var/log/antnode/$node_name
+    echo "mkdir -p $NodeStorage/$node_name"
+    sudo cp $NodePath $NodeStorage/$node_name
+    echo "cp $NodePath $NodeStorage/$node_name"
+    sudo chown -R ant:ant $NodeStorage/$node_name /var/log/antnode/$node_name $NodeStorage/$node_name/antnode
     echo "ownership changed to user ant"
     sudo tee /etc/systemd/system/"$node_name".service 2>&1 >/dev/null <<EOF
 [Unit]
 Description=$node_name
 [Service]
 User=ant
-ExecStart=/var/antctl/services/$node_name/antnode --bootstrap-cache-dir /var/antctl/bootstrap-cache --root-dir /var/antctl/services/$node_name --port $ntpr$node_number --enable-metrics-server --metrics-server-port 13$node_number --log-output-dest /var/log/antnode/$node_name --max-log-files 1 --max-archived-log-files 1 $RewardsAddress evm-arbitrum-one
+ExecStart=$NodeStorage/$node_name/antnode --bootstrap-cache-dir /var/antctl/bootstrap-cache --root-dir $NodeStorage/$node_name --port $ntpr$node_number --enable-metrics-server --metrics-server-port 13$node_number --log-output-dest /var/log/antnode/$node_name --max-log-files 1 --max-archived-log-files 1 $RewardsAddress evm-arbitrum-one
 Restart=always
 #RestartSec=300
 EOF
@@ -217,8 +219,8 @@ RemoveNode() {
     echo "Removing $node_name" && echo
     sudo systemctl stop --now $node_name
     echo "Stopping $node_name"
-    sudo rm -rf /var/antctl/services/$node_name /var/log/antnode/$node_name
-    echo "rm -rf /var/antctl/services/$node_name /var/log/antnode/$node_name"
+    sudo rm -rf $NodeStorage/$node_name /var/log/antnode/$node_name
+    echo "rm -rf $NodeStorage/$node_name /var/log/antnode/$node_name"
     sudo rm /etc/systemd/system/$node_name.service
     echo "rm /etc/systemd/system/$node_name.service"
     sudo systemctl daemon-reload
@@ -269,10 +271,10 @@ UpgradeNode() {
     sudo systemctl stop $node_name
     echo "systemctl stop $node_name"
     # remove old node data on upgrade
-    sudo rm -rf /var/antctl/services/$node_name/*
-    echo "rm -rf /var/antctl/services/$node_name/*"
-    sudo cp $NodePath /var/antctl/services/$node_name
-    echo "cp $NodePath /var/antctl/services/$node_name"
+    sudo rm -rf $NodeStorage/$node_name/*
+    echo "rm -rf $NodeStorage/$node_name/*"
+    sudo cp $NodePath $NodeStorage/$node_name
+    echo "cp $NodePath $NodeStorage/$node_name"
     sudo systemctl start $node_name
     echo "systemctl start $node_name"
     sleep 45
@@ -280,7 +282,7 @@ UpgradeNode() {
     # PeerId=$(echo "$status" | grep "id=" | cut -f2 -d= | cut -d '`' -f 1)
     node_metadata="$(curl -s 127.0.0.1:13$node_number/metadata)"
     PeerId="$(echo "$node_metadata" | grep ant_networking_peer_id | awk 'NR==3 {print $1}' | cut -d'"' -f 2)"
-    node_details_store[$node_number]="$node_name,$PeerId,$(/var/antctl/services/$node_name/antnode --version | awk 'NR==1 {print $3}' | cut -c2-),RUNNING"
+    node_details_store[$node_number]="$node_name,$PeerId,$($NodeStorage/$node_name/antnode --version | awk 'NR==1 {print $3}' | cut -c2-),RUNNING"
     echo "updated array"
     sed -i 's/CounterUpgrade=.*/CounterUpgrade='$DelayUpgrade'/g' /var/antctl/counters
     echo "reset node upgrade timer" && echo
@@ -292,12 +294,12 @@ StoppedUpgrade() {
     echo ""$time_hour":"$time_min" Upgrade $node_name stopped" >>/var/antctl/simplelog
     echo "upgradeing $node_name"
     # remove old node data on upgrade
-    sudo rm -rf /var/antctl/services/$node_name/*
-    echo "rm -rf /var/antctl/services/$node_name/*"
-    sudo cp $NodePath /var/antctl/services/$node_name
-    echo "cp $NodePath /var/antctl/services/$node_name"
+    sudo rm -rf $NodeStorage/$node_name/*
+    echo "rm -rf $NodeStorage/$node_name/*"
+    sudo cp $NodePath $NodeStorage/$node_name
+    echo "cp $NodePath $NodeStorage/$node_name"
     PIS=$(echo "${node_details_store[$node_number]}" | awk -F',' '{print $2}')
-    node_details_store[$node_number]="$node_name,$PIS,$(/var/antctl/services/$node_name/antnode --version | awk 'NR==1 {print $3}' | cut -c2-),STOPPED"
+    node_details_store[$node_number]="$node_name,$PIS,$($NodeStorage/$node_name/antnode --version | awk 'NR==1 {print $3}' | cut -c2-),STOPPED"
     echo "updated array" && echo
 }
 
@@ -306,7 +308,7 @@ CalculateValues() {
         echo "${node_details_store[$num]}"
     done)
 
-    TotalNodes=$(ls /var/antctl/services | wc -l)
+    TotalNodes=$(ls $NodeStorage | wc -l)
     RunningNodes=$(echo "$ArrayAsString" | grep -c "RUNNING")
     StoppedNodes=$(echo "$ArrayAsString" | grep -c "STOPPED")
     if (($(echo "$StoppedNodes > 0" | bc))); then
@@ -347,7 +349,7 @@ CalculateValues() {
     UsedCpuPercent=$(vmstat 1 2 | awk 'END { print 100 - $15 }')
     FreeMemPercent=$(free | grep Mem | awk '{ printf("%.4f\n", $7/$2 * 100.0) }')
     UsedMemPercent=$(echo "100 - $FreeMemPercent" | bc)
-    UsedHdPercent=$(df -hP /var | awk '{print $5}' | tail -1 | sed 's/%$//g')
+    UsedHdPercent=$(df -hP $NodeStorage | awk '{print $5}' | tail -1 | sed 's/%$//g')
     AllowCpu=$(echo "$UsedCpuPercent < $CpuLessThan" | bc)
     AllowMem=$(echo "$UsedMemPercent < $MemLessThan" | bc)
     AllowHD=$(echo "$UsedHdPercent < $HDLessThan" | bc)
@@ -459,11 +461,11 @@ ShunnGun() {
         # copy wallet to folder for later scraping
         WalletDir=""$(date +%s)"-"$node_name"-Shunn"
         mkdir -p $HOME/.local/share/wallets/$WalletDir/wallet
-        cp -r /var/antctl/services/$node_name/wallet/* $HOME/.local/share/wallets/$WalletDir/wallet
-        sudo rm -rf /var/antctl/services/$node_name/*
+        cp -r $NodeStorage/$node_name/wallet/* $HOME/.local/share/wallets/$WalletDir/wallet
+        sudo rm -rf $NodeStorage/$node_name/*
         sleep 5
-        sudo cp $NodePath /var/antctl/services/$node_name
-        echo "cp $NodePath /var/antctl/services/$node_name"
+        sudo cp $NodePath $NodeStorage/$node_name
+        echo "cp $NodePath $NodeStorage/$node_name"
         sleep 5
         #restart node
         echo "Starting $node_name"
@@ -472,7 +474,7 @@ ShunnGun() {
         sleep 30
         status="$(sudo systemctl status $node_name.service --no-page)"
         PeerId=$(echo "$status" | grep "id=" | cut -f2 -d= | cut -d '`' -f 1)
-        node_details_store[$node_number]="$node_name,$PeerId,$(/var/antctl/services/$node_name/antnode --version | awk 'NR==1 {print $3}' | cut -c2-),RUNNING"
+        node_details_store[$node_number]="$node_name,$PeerId,$($NodeStorage/$node_name/antnode --version | awk 'NR==1 {print $3}' | cut -c2-),RUNNING"
         echo "$node_name Started"
         sed -i 's/CounterStart=.*/CounterStart='$DelayStart'/g' /var/antctl/counters
         echo "reset node start timer" && echo
@@ -502,16 +504,16 @@ LoadTrimmer() {
             echo "replacing $node_name"
             sudo systemctl stop $node_name
             echo "systemctl stop $node_name"
-            sudo rm -rf /var/antctl/services/$node_name/*
-            echo "rm -rf /var/antctl/services/$node_name/*"
-            sudo cp $NodePath /var/antctl/services/$node_name
-            echo "cp $NodePath /var/antctl/services/$node_name"
+            sudo rm -rf $NodeStorage/$node_name/*
+            echo "rm -rf $NodeStorage/$node_name/*"
+            sudo cp $NodePath $NodeStorage/$node_name
+            echo "cp $NodePath $NodeStorage/$node_name"
             sudo systemctl start $node_name
             echo "systemctl start $node_name"
             sleep 45
             node_metadata="$(curl -s 127.0.0.1:13$node_number/metadata)"
             PeerId="$(echo "$node_metadata" | grep ant_networking_peer_id | awk 'NR==3 {print $1}' | cut -d'"' -f 2)"
-            node_details_store[$node_number]="$node_name,$PeerId,$(/var/antctl/services/$node_name/antnode --version | awk 'NR==1 {print $3}' | cut -c2-),RUNNING"
+            node_details_store[$node_number]="$node_name,$PeerId,$($NodeStorage/$node_name/antnode --version | awk 'NR==1 {print $3}' | cut -c2-),RUNNING"
             echo "updated array"
         fi
     fi


### PR DESCRIPTION
This adds a question that defaults to /var/antctl/services.

Now we can use a separate mounted volume for node storage.
anms.sh correctly sees the mounted volume when creating nodes limits.