### PR TITLE
Add support for Node storage volume

### DIFF
--- a/anm/anm-local.sh
+++ b/anm/anm-local.sh
@@ -178,8 +178,8 @@ elif [[ "$SELECTION" == "7" ]]; then
         exit 0
     fi
     # Set new storage location
-    sudo sed -i 's,/var/antctl/services,/'$NodeStorage'/g' /usr/bin/anms.sh
-
+    sudo sed -i 's,/var/antctl/services,'$NodeStorage',g' /usr/bin/anms.sh
+    
     ### set nodecount
     NodeCount=$(whiptail --title "Set node count" --inputbox "\nEnter node count" 8 40 "20" 3>&1 1>&2 2>&3)
     if [[ $? -eq 255 ]]; then

--- a/anm/anm-local.sh
+++ b/anm/anm-local.sh
@@ -172,6 +172,14 @@ elif [[ "$SELECTION" == "7" ]]; then
     # Set new rewards address
     sudo sed -i 's/--rewards-address EtheriumAddress/--rewards-address '$RewardsAddress'/g' /usr/bin/anms.sh
 
+    ### set node storage location
+    NodeStorage=$(whiptail --title "Node Storage Location" --inputbox "\nEnter the path to store node information" 8 40 "/var/antctl/services/" 3>&1 1>&2 2>&3)
+    if [[ $? -eq 255 ]]; then
+        exit 0
+    fi
+    # Set new storage location
+    sudo sed -i 's,/var/antctl/services,/'$NodeStorage'/g' /usr/bin/anms.sh
+
     ### set nodecount
     NodeCount=$(whiptail --title "Set node count" --inputbox "\nEnter node count" 8 40 "20" 3>&1 1>&2 2>&3)
     if [[ $? -eq 255 ]]; then

--- a/anm/anm-local.sh
+++ b/anm/anm-local.sh
@@ -179,6 +179,7 @@ elif [[ "$SELECTION" == "7" ]]; then
     fi
     # Set new storage location
     sudo sed -i 's,/var/antctl/services,'$NodeStorage',g' /usr/bin/anms.sh
+    sudo sed -i 's,/var/antctl/services,'$NodeStorage',g' /usr/bin/influx-resources.sh
     
     ### set nodecount
     NodeCount=$(whiptail --title "Set node count" --inputbox "\nEnter node count" 8 40 "20" 3>&1 1>&2 2>&3)

--- a/anm/scripts/anms.sh
+++ b/anm/scripts/anms.sh
@@ -190,7 +190,7 @@ TearDown() {
     sudo rm -f /etc/cron.d/scrape
     sudo rm -f /usr/bin/scrape.sh
     sudo rm -f $HOME/scrape
-    sudo rm -rf /var/antctl
+    sudo rm -rf $NodeStorage /var/antctl
     sudo rm -rf /home/ant/.local/share/autonomi/node
     sleep 5
     sudo rm -rf /var/antctl

--- a/anm/scripts/anms.sh
+++ b/anm/scripts/anms.sh
@@ -82,7 +82,7 @@ CheckSetUp() {
 =======
         echo >>/var/antctl/config
         echo "NodeStorage=/var/antctl/services" >>/var/antctl/config
->>>>>>> ec664f9 (typo)
+        echo "NodeStorage=/var/antctl/services" >>/var/antctl/teardown_config
         echo >>/var/antctl/config
         echo "NodeCap=20" >>/var/antctl/config
         echo >>/var/antctl/config
@@ -175,6 +175,7 @@ EOF
 
 TearDown() {
     echo "Nuke sequence initiated !!" && echo
+    . /var/antctl/teardown_config
     sudo rm /etc/cron.d/anm
     echo "rm /etc/cron.d/anm"
     sudo systemctl stop antnode*

--- a/anm/scripts/anms.sh
+++ b/anm/scripts/anms.sh
@@ -198,7 +198,7 @@ TearDown() {
     sudo rm -rf $NodeStorage /var/antctl
     sudo rm -rf /home/ant/.local/share/autonomi/node
     sleep 5
-    sudo rm -rf /var/antctl
+    sudo rm -rf $NodeStorage /var/antctl
     sudo rm -rf /home/ant/.local/share/autonomi/node
     # save all wallets for later scraping
     #cp -r /var/antctl/wallets $HOME/.local/share/wallets

--- a/anm/scripts/anms.sh
+++ b/anm/scripts/anms.sh
@@ -78,8 +78,6 @@ CheckSetUp() {
         echo "DelayReStart=5" >>/var/antctl/config
         echo "DelayUpgrade=5" >>/var/antctl/config
         echo "DelayRemove=10" >>/var/antctl/config
-<<<<<<< HEAD
-=======
         echo >>/var/antctl/config
         echo "NodeStorage=/var/antctl/services" >>/var/antctl/config
         echo "NodeStorage=/var/antctl/services" >>/var/antctl/teardown_config

--- a/anm/scripts/anms.sh
+++ b/anm/scripts/anms.sh
@@ -78,6 +78,11 @@ CheckSetUp() {
         echo "DelayReStart=5" >>/var/antctl/config
         echo "DelayUpgrade=5" >>/var/antctl/config
         echo "DelayRemove=10" >>/var/antctl/config
+<<<<<<< HEAD
+=======
+        echo >>/var/antctl/config
+        echo "NodeStorage=/var/antctl/services" >>/var/antctl/config
+>>>>>>> ec664f9 (typo)
         echo >>/var/antctl/config
         echo "NodeCap=20" >>/var/antctl/config
         echo >>/var/antctl/config

--- a/influx-resources.sh
+++ b/influx-resources.sh
@@ -122,7 +122,7 @@ for ((i = 1; i <= $NumberOfNodes; i++)); do
         else
             # for antctl node manager service
             PeerId="\"NotReachableStoppedNode\""
-            NodeVersion="\"$(/var/antctl/services/antnode$i/antnode -V | awk '{print $3}')\""
+            NodeVersion="\"$(${base_dir}/antnode$i/antnode -V | awk '{print $3}')\""
         fi
     fi
 
@@ -179,7 +179,7 @@ fi
 
 # calculate total storage of the node services folder
 total_disk=$(echo "scale=0;("$(du -s "$base_dir" | cut -f1)")/1024" | bc)
-UsedHdPercent=$(df -hP /var | awk '{print $5}' | tail -1 | sed 's/%$//g')
+UsedHdPercent=$(df -hP ${base_dir} | awk '{print $5}' | tail -1 | sed 's/%$//g')
 
 # sleep till all nodes have systems have finished prosessing
 


### PR DESCRIPTION
This adds support for using a different storage path than /var/antctl/services so we can use separate disks/volumes.

After anm-local.sh gathers the updatable path, the value gets replaced in /usr/bin/anms.sh and /usr/bin/influx-resources.sh

anms.sh, on first execution now creates a config file (teardown_config) for the storage location that will get loaded during teardown (after the regular config file is already removed).
on teardown, the new file is loaded, then the storage path and config files are remove

This solution has one known issue.  If the user updates the influx-resources.sh after starting nodes, they will need another solution (manually?) to update the 'base_dir' variable inside the script to match the Node Storage location. A partial solution could be to extend the anm-local.sh script to ask for the storage path when doing the NTracking update option.
