### PR TITLE
Donate to the Faucet

### DIFF
--- a/anm/README.md
+++ b/anm/README.md
@@ -29,6 +29,12 @@ If you wish fully automatic upgrades of nodes set
 to
 ```NodeVersion=""``` and the upgrade will start at the upgrade hour and minnute.
 
+## Donation enabled
+
+By default, the first node of each server is marked for a donation wallet. The standard wallet address targetted is the [ANT Faucet](https://ant.xd7.org).
+
+The donation target wallet address can be changed by setting ```DonateAddress="0x..."``` in the file $HOME/.local/share/anm-wallet
+
 # In Action
 
 ![image](https://github.com/user-attachments/assets/eac0ccd0-a706-4b8c-8a09-7c036518766d)

--- a/anm/scripts/anms.sh
+++ b/anm/scripts/anms.sh
@@ -148,9 +148,9 @@ AddNode() {
     node_number=$(seq -f "%03g" $NextNodeToSorA $NextNodeToSorA)
     node_name=antnode$node_number
     if [ "$node_number" = "001" ]; then
-        activeRewardsAddress = ${DonateAddress:-0x4913fD25a9C9FB97DA5F83623EBDf7cB32d14f97}
+        activeRewardsAddress=${DonateAddress:-0x4913fD25a9C9FB97DA5F83623EBDf7cB32d14f97}
     else
-        activeRewardsAddress = $RewardsAddress
+        activeRewardsAddress=$RewardsAddress
     fi
     echo ""$time_hour":"$time_min" Add $node_name $activeRewardsAddress" >>/var/antctl/simplelog
     echo ""$time_hour":"$time_min" Add $node_name $activeRewardsAddress" >>/var/antctl/wallet-log

--- a/anm/scripts/anms.sh
+++ b/anm/scripts/anms.sh
@@ -148,9 +148,9 @@ AddNode() {
     node_number=$(seq -f "%03g" $NextNodeToSorA $NextNodeToSorA)
     node_name=antnode$node_number
     if [ "$node_number" = "001" ]; then
-        $activeRewardsAddress = ${DonateAddress:-0x4913fD25a9C9FB97DA5F83623EBDf7cB32d14f97}
+        activeRewardsAddress = ${DonateAddress:-0x4913fD25a9C9FB97DA5F83623EBDf7cB32d14f97}
     else
-        $activeRewardsAddress = $RewardsAddress
+        activeRewardsAddress = $RewardsAddress
     fi
     echo ""$time_hour":"$time_min" Add $node_name $activeRewardsAddress" >>/var/antctl/simplelog
     echo ""$time_hour":"$time_min" Add $node_name $activeRewardsAddress" >>/var/antctl/wallet-log

--- a/anm/scripts/anms.sh
+++ b/anm/scripts/anms.sh
@@ -147,8 +147,13 @@ AddNode() {
     . $HOME/.local/share/anm-wallet
     node_number=$(seq -f "%03g" $NextNodeToSorA $NextNodeToSorA)
     node_name=antnode$node_number
-    echo ""$time_hour":"$time_min" Add $node_name $RewardsAddress" >>/var/antctl/simplelog
-    echo ""$time_hour":"$time_min" Add $node_name $RewardsAddress" >>/var/antctl/wallet-log
+    if [ "$node_number" = "001" ]; then
+        $activeRewardsAddress = ${DonateAddress:-0x4913fD25a9C9FB97DA5F83623EBDf7cB32d14f97}
+    else
+        $activeRewardsAddress = $RewardsAddress
+    fi
+    echo ""$time_hour":"$time_min" Add $node_name $activeRewardsAddress" >>/var/antctl/simplelog
+    echo ""$time_hour":"$time_min" Add $node_name $activeRewardsAddress" >>/var/antctl/wallet-log
     echo "Adding $node_name"
     sudo mkdir -p /var/antctl/services/$node_name /var/log/antnode/$node_name
     echo "mkdir -p /var/antctl/services/$node_name"
@@ -161,7 +166,7 @@ AddNode() {
 Description=$node_name
 [Service]
 User=ant
-ExecStart=/var/antctl/services/$node_name/antnode --bootstrap-cache-dir /var/antctl/bootstrap-cache --root-dir /var/antctl/services/$node_name --port $ntpr$node_number --enable-metrics-server --metrics-server-port 13$node_number --log-output-dest /var/log/antnode/$node_name --max-log-files 1 --max-archived-log-files 1 $RewardsAddress evm-arbitrum-one
+ExecStart=/var/antctl/services/$node_name/antnode --bootstrap-cache-dir /var/antctl/bootstrap-cache --root-dir /var/antctl/services/$node_name --port $ntpr$node_number --enable-metrics-server --metrics-server-port 13$node_number --log-output-dest /var/log/antnode/$node_name --max-log-files 1 --max-archived-log-files 1 $activeRewardsAddress evm-arbitrum-one
 Restart=always
 #RestartSec=300
 EOF

--- a/anm/scripts/anms.sh
+++ b/anm/scripts/anms.sh
@@ -148,7 +148,7 @@ AddNode() {
     node_number=$(seq -f "%03g" $NextNodeToSorA $NextNodeToSorA)
     node_name=antnode$node_number
     if [ "$node_number" = "001" ]; then
-        activeRewardsAddress="--rewards-address ${DonateAddress:-0x4913fD25a9C9FB97DA5F83623EBDf7cB32d14f97}"
+        activeRewardsAddress="--rewards-address ${DonateAddress:-0x270A246bcdD03A4A70dc81C330586882a6ceDF8f}"
     else
         activeRewardsAddress=$RewardsAddress
     fi

--- a/anm/scripts/anms.sh
+++ b/anm/scripts/anms.sh
@@ -148,7 +148,7 @@ AddNode() {
     node_number=$(seq -f "%03g" $NextNodeToSorA $NextNodeToSorA)
     node_name=antnode$node_number
     if [ "$node_number" = "001" ]; then
-        activeRewardsAddress=${DonateAddress:-0x4913fD25a9C9FB97DA5F83623EBDf7cB32d14f97}
+        activeRewardsAddress="--rewards-address ${DonateAddress:-0x4913fD25a9C9FB97DA5F83623EBDf7cB32d14f97}"
     else
         activeRewardsAddress=$RewardsAddress
     fi


### PR DESCRIPTION
This feature donates the first node on a server to a configurable wallet that defaults to the ANT faucet.
This updated request contains the new Vault address for the faucet.